### PR TITLE
Replace Species Count Hardcoded Date

### DIFF
--- a/INatExplorer/Network/NetworkRequest.swift
+++ b/INatExplorer/Network/NetworkRequest.swift
@@ -91,7 +91,7 @@ class NetworkRequest {
         var requestUrl = URL(string: Constants.iNatBaseUrl + SpeciesCounts.endpoint)
         var queryItems: [URLQueryItem] = [
             .init(name: SpeciesCounts.iconicTaxon, value: category.paramValue),
-            .init(name: SpeciesCounts.fromDate, value: "2024-01-01"),
+            .init(name: SpeciesCounts.fromDate, value: DateUtil.getPastYearDateString()),
         ]
         
         queryItems += Constants.commonParams

--- a/INatExplorer/Util/DateUtil.swift
+++ b/INatExplorer/Util/DateUtil.swift
@@ -17,6 +17,16 @@ class DateUtil {
         static let dateFormatDayLen = mdFormat.count
     }
     
+    static func getPastYearDateString() -> String {
+        let calendar = Calendar.current
+        let today = Date()
+        let lastYearDate = calendar.date(byAdding: DateComponents(year: -1, day: -1), to: today)!
+        
+        let DateFormatter = DateFormatter()
+        DateFormatter.dateFormat = Constants.dateFormat
+        return DateFormatter.string(from: lastYearDate)
+    }
+    
     static func getPastYearDateList() -> [DateWithString] {
         let calendar = Calendar.current
         let today = Date()

--- a/INatExplorer/ViewModels/ReportHistogram.swift
+++ b/INatExplorer/ViewModels/ReportHistogram.swift
@@ -65,6 +65,7 @@ struct ReportCount: Hashable {
         
         guard
             let lastYearMax = lastYearCounts.map({ $0.1 }).max(),
+            lastYearMax > 0,
             let historicalMax = historicalCounts.max()
         else {
             print("Histogram data error!")

--- a/INatExplorerTests/INatExplorerTests.swift
+++ b/INatExplorerTests/INatExplorerTests.swift
@@ -6,7 +6,7 @@
 //
 
 import Testing
-@testable import INatExplorer
+@testable import iNatExplorer
 
 struct INatExplorerTests {
 


### PR DESCRIPTION
Replace hardcoded "from date" (`d1`) parameter of get species count API.

Test Bitrise integration.