### PR TITLE
Add observed status for species

### DIFF
--- a/INatExplorer/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/INatExplorer/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.331",
+          "green" : "0.600",
+          "red" : "0.400"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/INatExplorer/INatExplorerApp.swift
+++ b/INatExplorer/INatExplorerApp.swift
@@ -15,6 +15,6 @@ struct INatExplorerApp: App {
         WindowGroup {
             ContentView()
         }
-        .modelContainer(for: Filter.self)
+        .modelContainer(for: [Filter.self, SavedSpecies.self])
     }
 }

--- a/INatExplorer/Models/SavedSpecies.swift
+++ b/INatExplorer/Models/SavedSpecies.swift
@@ -1,0 +1,25 @@
+//
+//  SavedSpecies.swift
+//  iNatExplorer
+//
+//  Created by Yuanfeng Jiao on 5/27/25.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+class SavedSpecies {
+    
+    enum Label: Codable {
+        case sighted
+    }
+    
+    var taxonId: Int
+    var labels: [Label]
+    
+    init(taxonId: Int, labels: [Label]) {
+        self.taxonId = taxonId
+        self.labels = labels
+    }
+}

--- a/INatExplorer/Models/SavedSpecies.swift
+++ b/INatExplorer/Models/SavedSpecies.swift
@@ -12,7 +12,7 @@ import SwiftData
 class SavedSpecies {
     
     enum Label: Codable {
-        case sighted
+        case observed
     }
     
     var taxonId: Int

--- a/INatExplorer/Models/SavedSpecies.swift
+++ b/INatExplorer/Models/SavedSpecies.swift
@@ -22,4 +22,18 @@ class SavedSpecies {
         self.taxonId = taxonId
         self.labels = labels
     }
+    
+    func hasLabel(_ label: Label) -> Bool {
+        return labels.contains(label)
+    }
+    
+    func addLabel(_ label: Label) {
+        guard !labels.contains(label) else { return }
+        
+        self.labels.append(label)
+    }
+    
+    func removeLabel(_ label: Label) {
+        self.labels.removeAll(where: { $0 == label })
+    }
 }

--- a/INatExplorer/Views/Report/FilterView.swift
+++ b/INatExplorer/Views/Report/FilterView.swift
@@ -28,7 +28,7 @@ struct FilterView: View {
         }
     }
     
-    @Environment(\.modelContext) var modelContext
+    @Environment(\.modelContext) private var modelContext
     
     var filterSection: FilterSection
     

--- a/INatExplorer/Views/Species/SpeciesDetailView.swift
+++ b/INatExplorer/Views/Species/SpeciesDetailView.swift
@@ -14,6 +14,8 @@ struct SpeciesDetailView: View {
     @StateObject var taxonNamesViewModel = TaxonNamesViewModel()
     @StateObject var histogramViewModel = ReportHistogramViewModel()
     
+    @Binding var observed: Bool
+    
     var body: some View {
         ScrollView {
             HStack {
@@ -33,6 +35,19 @@ struct SpeciesDetailView: View {
                     .scaledToFit()
             } placeholder: {
                 Color.gray
+            }
+            .overlay(alignment: .topTrailing) {
+                Button {
+                    observed.toggle()
+                } label: {
+                    Image(systemName: SpeciesListView.Constants.observedIcon)
+                        .resizable()
+                        .scaledToFit()
+                        .padding(4)
+                        .shadow(color: .gray, radius: 2)
+                }
+                .frame(width: 35, height: 35)
+                .tint(observed ? .orange : .gray)
             }
             
             let lastYearHistogram = histogramViewModel.lastYearHistogram
@@ -107,5 +122,7 @@ struct SpeciesDetailView: View {
 }
 
 #Preview {
-    SpeciesDetailView(species: Species.Constants.preview)
+    @Previewable @State var observed: Bool = false
+    
+    SpeciesDetailView(species: Species.Constants.preview, observed: $observed)
 }

--- a/INatExplorer/Views/Species/SpeciesItemView.swift
+++ b/INatExplorer/Views/Species/SpeciesItemView.swift
@@ -11,6 +11,8 @@ struct SpeciesItemView: View {
     
     var species: Species
     
+    @Binding var isSighted: Bool
+    
     var body: some View {
         ZStack(alignment: .bottom) {
             AsyncImage(url: species.photo?.getUrl(.small)) { image in
@@ -38,7 +40,7 @@ struct SpeciesItemView: View {
             }
             .overlay(alignment: .topTrailing) {
                 Button {
-                    
+                    isSighted.toggle()
                 } label: {
                     Image(systemName: "binoculars.fill")
                         .resizable()
@@ -47,12 +49,14 @@ struct SpeciesItemView: View {
                         .shadow(color: .gray, radius: 2)
                 }
                 .frame(width: 35, height: 35)
-                .tint(.gray)
+                .tint(isSighted ? .orange : .gray)
             }
         }
     }
 }
 
 #Preview {
-    SpeciesItemView(species: Species.Constants.preview)
+    @Previewable @State var isSighted: Bool = false
+    
+    SpeciesItemView(species: Species.Constants.preview, isSighted: $isSighted)
 }

--- a/INatExplorer/Views/Species/SpeciesItemView.swift
+++ b/INatExplorer/Views/Species/SpeciesItemView.swift
@@ -42,7 +42,7 @@ struct SpeciesItemView: View {
                 Button {
                     observed.toggle()
                 } label: {
-                    Image(systemName: "binoculars.fill")
+                    Image(systemName: SpeciesListView.Constants.observedIcon)
                         .resizable()
                         .scaledToFit()
                         .padding(4)

--- a/INatExplorer/Views/Species/SpeciesItemView.swift
+++ b/INatExplorer/Views/Species/SpeciesItemView.swift
@@ -28,14 +28,26 @@ struct SpeciesItemView: View {
             )
             .aspectRatio(1, contentMode: .fit)
             .clipped()
-            
-            VStack {
+            .overlay(alignment: .bottom) {
                 Text(verbatim: "\(species.name)\n\(species.count)")
                     .font(.callout)
                     .accentColor(.white)
                     .shadow(color: .black, radius: 2)
                     .multilineTextAlignment(.center)
                     .padding(.bottom, 4)
+            }
+            .overlay(alignment: .topTrailing) {
+                Button {
+                    
+                } label: {
+                    Image(systemName: "binoculars.fill")
+                        .resizable()
+                        .scaledToFit()
+                        .padding(4)
+                        .shadow(color: .gray, radius: 2)
+                }
+                .frame(width: 35, height: 35)
+                .tint(.gray)
             }
         }
     }

--- a/INatExplorer/Views/Species/SpeciesItemView.swift
+++ b/INatExplorer/Views/Species/SpeciesItemView.swift
@@ -11,7 +11,7 @@ struct SpeciesItemView: View {
     
     var species: Species
     
-    @Binding var isSighted: Bool
+    @Binding var observed: Bool
     
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -40,7 +40,7 @@ struct SpeciesItemView: View {
             }
             .overlay(alignment: .topTrailing) {
                 Button {
-                    isSighted.toggle()
+                    observed.toggle()
                 } label: {
                     Image(systemName: "binoculars.fill")
                         .resizable()
@@ -49,14 +49,14 @@ struct SpeciesItemView: View {
                         .shadow(color: .gray, radius: 2)
                 }
                 .frame(width: 35, height: 35)
-                .tint(isSighted ? .orange : .gray)
+                .tint(observed ? .orange : .gray)
             }
         }
     }
 }
 
 #Preview {
-    @Previewable @State var isSighted: Bool = false
+    @Previewable @State var observed: Bool = false
     
-    SpeciesItemView(species: Species.Constants.preview, isSighted: $isSighted)
+    SpeciesItemView(species: Species.Constants.preview, observed: $observed)
 }

--- a/INatExplorer/Views/Species/SpeciesItemView.swift
+++ b/INatExplorer/Views/Species/SpeciesItemView.swift
@@ -14,43 +14,41 @@ struct SpeciesItemView: View {
     @Binding var observed: Bool
     
     var body: some View {
-        ZStack(alignment: .bottom) {
-            AsyncImage(url: species.photo?.getUrl(.small)) { image in
-                image
+        AsyncImage(url: species.photo?.getUrl(.small)) { image in
+            image
+                .resizable()
+                .scaledToFill()
+        } placeholder: {
+            Color.gray
+        }
+        .frame(
+            minWidth: 0,
+            maxWidth: .infinity,
+            minHeight: 0,
+            maxHeight: .infinity
+        )
+        .aspectRatio(1, contentMode: .fit)
+        .clipped()
+        .overlay(alignment: .bottom) {
+            Text(verbatim: "\(species.name)\n\(species.count)")
+                .font(.callout)
+                .accentColor(.white)
+                .shadow(color: .black, radius: 2)
+                .multilineTextAlignment(.center)
+                .padding(.bottom, 4)
+        }
+        .overlay(alignment: .topTrailing) {
+            Button {
+                observed.toggle()
+            } label: {
+                Image(systemName: SpeciesListView.Constants.observedIcon)
                     .resizable()
-                    .scaledToFill()
-            } placeholder: {
-                Color.gray
+                    .scaledToFit()
+                    .padding(4)
+                    .shadow(color: .gray, radius: 2)
             }
-            .frame(
-                minWidth: 0,
-                maxWidth: .infinity,
-                minHeight: 0,
-                maxHeight: .infinity
-            )
-            .aspectRatio(1, contentMode: .fit)
-            .clipped()
-            .overlay(alignment: .bottom) {
-                Text(verbatim: "\(species.name)\n\(species.count)")
-                    .font(.callout)
-                    .accentColor(.white)
-                    .shadow(color: .black, radius: 2)
-                    .multilineTextAlignment(.center)
-                    .padding(.bottom, 4)
-            }
-            .overlay(alignment: .topTrailing) {
-                Button {
-                    observed.toggle()
-                } label: {
-                    Image(systemName: SpeciesListView.Constants.observedIcon)
-                        .resizable()
-                        .scaledToFit()
-                        .padding(4)
-                        .shadow(color: .gray, radius: 2)
-                }
-                .frame(width: 35, height: 35)
-                .tint(observed ? .orange : .gray)
-            }
+            .frame(width: 35, height: 35)
+            .tint(observed ? .orange : .gray)
         }
     }
 }

--- a/INatExplorer/Views/Species/SpeciesListView.swift
+++ b/INatExplorer/Views/Species/SpeciesListView.swift
@@ -10,14 +10,16 @@ import SwiftData
 
 struct SpeciesListView: View {
     
+    var category: CategoryStruct
+    
+    @Environment(\.modelContext) private var modelContext
+    
     @StateObject private var speciesViewModel = SpeciesViewModel()
     @State private var families: [Family] = []
     @State private var speciesCount: Int = 0
     @State private var isLoading: Bool = true
     
     @Query private var savedSpecies: [SavedSpecies]
-    
-    var category: CategoryStruct
     
     private var speciesCountDisplay: String {
         speciesCount <= 500 ? String(speciesCount) : "500 (max)"
@@ -40,7 +42,21 @@ struct SpeciesListView: View {
                         Section {
                             ForEach(family.species) { species in
                                 NavigationLink(destination: SpeciesDetailView(species: species)) {
-                                    SpeciesItemView(species: species)
+                                    SpeciesItemView(
+                                        species: species,
+                                        isSighted: Binding(
+                                            get: {
+                                                savedSpeciesDict[species.id]?.hasLabel(.sighted) ?? false
+                                            },
+                                            set: { newValue in
+                                                if newValue {
+                                                    addLabel(for: species, label: .sighted)
+                                                } else {
+                                                    removeLabel(for: species, label: .sighted)
+                                                }
+                                            }
+                                        )
+                                    )
                                 }
                                 .navigationTitle("Species List")
                             }
@@ -76,6 +92,26 @@ struct SpeciesListView: View {
             }
             .opacity(isLoading ? 1 : 0)
         }
+    }
+    
+    private func addLabel(for species: Species, label: SavedSpecies.Label) {
+        let taxonId = species.taxon.id
+        if savedSpeciesDict[taxonId] != nil {
+            savedSpecies.first(where: { $0.taxonId == taxonId })?.addLabel(label)
+        } else {
+            modelContext.insert(SavedSpecies(taxonId: taxonId, labels: [label]))
+        }
+    }
+    
+    private func removeLabel(for species: Species, label: SavedSpecies.Label) {
+        guard let savedSpeciesItem = savedSpecies.first(where: { $0.taxonId == species.taxon.id })
+        else { return }
+        
+        savedSpeciesItem.removeLabel(label)
+        if savedSpeciesItem.labels.isEmpty {
+            modelContext.delete(savedSpeciesItem)
+        }
+        try? modelContext.save()
     }
 }
 

--- a/INatExplorer/Views/Species/SpeciesListView.swift
+++ b/INatExplorer/Views/Species/SpeciesListView.swift
@@ -15,30 +15,55 @@ struct SpeciesListView: View {
     @Environment(\.modelContext) private var modelContext
     
     @StateObject private var speciesViewModel = SpeciesViewModel()
-    @State private var families: [Family] = []
-    @State private var speciesCount: Int = 0
     @State private var isLoading: Bool = true
     
     @Query private var savedSpecies: [SavedSpecies]
     
+    @AppStorage("hideObserved") private var hideObserved: Bool = false
+    
     private var speciesCountDisplay: String {
-        speciesCount <= 500 ? String(speciesCount) : "500 (max)"
+        let speciesCount = speciesViewModel.speciesCount
+        return speciesCount <= 500 ? String(speciesCount) : "500 (max)"
     }
     
     private var savedSpeciesDict: [Int: SavedSpecies] {
         Dictionary(uniqueKeysWithValues: savedSpecies.map { ($0.taxonId, $0) })
     }
     
+    private var filteredFamilies: [Family] {
+        guard hideObserved else { return speciesViewModel.families }
+        
+        return speciesViewModel.families.compactMap { family in
+            let filteredSpecies: [Species] = family.species.filter {
+                !savedSpeciesDict.keys.contains($0.id)
+            }
+            
+            if filteredSpecies.isEmpty { return nil }
+            
+            return Family(
+                taxon: family.taxon,
+                ancestors: family.ancestors,
+                species: filteredSpecies
+            )
+        }
+    }
+    
     var body: some View {
         ZStack {
             ScrollView {
-                Text("Total species: \(speciesCount)")
+                Text("Total species: \(speciesCountDisplay)")
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                    .padding(.horizontal)
+                
+                Toggle("Only Show Unobserved", isOn: $hideObserved)
+                    .padding(.horizontal)
+                    .listRowSeparator(.hidden)
                 
                 LazyVGrid(
                     columns: .init(repeating: GridItem(),count: 3),
                     alignment: .leading
                 ) {
-                    ForEach(families) { family in
+                    ForEach(filteredFamilies) { family in
                         Section {
                             ForEach(family.species) { species in
                                 NavigationLink(destination: SpeciesDetailView(species: species)) {
@@ -78,8 +103,6 @@ struct SpeciesListView: View {
                     guard isLoading else { return }
                     
                     await speciesViewModel.fetchData(category: category)
-                    families = speciesViewModel.families
-                    speciesCount = speciesViewModel.speciesCount
                     isLoading = false
                 }
             }

--- a/INatExplorer/Views/Species/SpeciesListView.swift
+++ b/INatExplorer/Views/Species/SpeciesListView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SwiftData
 
 struct SpeciesListView: View {
     
@@ -14,10 +15,16 @@ struct SpeciesListView: View {
     @State private var speciesCount: Int = 0
     @State private var isLoading: Bool = true
     
+    @Query private var savedSpecies: [SavedSpecies]
+    
     var category: CategoryStruct
     
     private var speciesCountDisplay: String {
         speciesCount <= 500 ? String(speciesCount) : "500 (max)"
+    }
+    
+    private var savedSpeciesDict: [Int: SavedSpecies] {
+        Dictionary(uniqueKeysWithValues: savedSpecies.map { ($0.taxonId, $0) })
     }
     
     var body: some View {

--- a/INatExplorer/Views/Species/SpeciesListView.swift
+++ b/INatExplorer/Views/Species/SpeciesListView.swift
@@ -44,15 +44,15 @@ struct SpeciesListView: View {
                                 NavigationLink(destination: SpeciesDetailView(species: species)) {
                                     SpeciesItemView(
                                         species: species,
-                                        isSighted: Binding(
+                                        observed: Binding(
                                             get: {
-                                                savedSpeciesDict[species.id]?.hasLabel(.sighted) ?? false
+                                                savedSpeciesDict[species.id]?.hasLabel(.observed) ?? false
                                             },
                                             set: { newValue in
                                                 if newValue {
-                                                    addLabel(for: species, label: .sighted)
+                                                    addLabel(for: species, label: .observed)
                                                 } else {
-                                                    removeLabel(for: species, label: .sighted)
+                                                    removeLabel(for: species, label: .observed)
                                                 }
                                             }
                                         )

--- a/INatExplorer/Views/Species/SpeciesListView.swift
+++ b/INatExplorer/Views/Species/SpeciesListView.swift
@@ -10,6 +10,10 @@ import SwiftData
 
 struct SpeciesListView: View {
     
+    enum Constants {
+        static let observedIcon: String = "binoculars.fill"
+    }
+    
     var category: CategoryStruct
     
     @Environment(\.modelContext) private var modelContext
@@ -66,21 +70,28 @@ struct SpeciesListView: View {
                     ForEach(filteredFamilies) { family in
                         Section {
                             ForEach(family.species) { species in
-                                NavigationLink(destination: SpeciesDetailView(species: species)) {
+                                let observedStatusBinding = Binding(
+                                    get: {
+                                        savedSpeciesDict[species.id]?.hasLabel(.observed) ?? false
+                                    },
+                                    set: { newValue in
+                                        if newValue {
+                                            addLabel(for: species, label: .observed)
+                                        } else {
+                                            removeLabel(for: species, label: .observed)
+                                        }
+                                    }
+                                )
+                                
+                                NavigationLink {
+                                    SpeciesDetailView(
+                                        species: species,
+                                        observed: observedStatusBinding
+                                    )
+                                } label: {
                                     SpeciesItemView(
                                         species: species,
-                                        observed: Binding(
-                                            get: {
-                                                savedSpeciesDict[species.id]?.hasLabel(.observed) ?? false
-                                            },
-                                            set: { newValue in
-                                                if newValue {
-                                                    addLabel(for: species, label: .observed)
-                                                } else {
-                                                    removeLabel(for: species, label: .observed)
-                                                }
-                                            }
-                                        )
+                                        observed: observedStatusBinding
                                     )
                                 }
                                 .navigationTitle("Species List")

--- a/INatExplorer/Views/UpdateFilterButtonView.swift
+++ b/INatExplorer/Views/UpdateFilterButtonView.swift
@@ -10,7 +10,7 @@ import SwiftData
 
 struct UpdateFilterButtonView: View {
     
-    @Environment(\.modelContext) var modelContext
+    @Environment(\.modelContext) private var modelContext
     @Query private var filters: [Filter]
     
     private var taxonFilter: Filter? {

--- a/iNatExplorer.xcodeproj/project.pbxproj
+++ b/iNatExplorer.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		378AF5C62D16104D00AC77A8 /* SpeciesDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378AF5C52D16104D00AC77A8 /* SpeciesDetailView.swift */; };
 		3793E1152D6AFDE000113EF5 /* aos_family_order.txt in Resources */ = {isa = PBXBuildFile; fileRef = 3793E1142D6AFDE000113EF5 /* aos_family_order.txt */; };
 		3793E1172D6AFE1000113EF5 /* AosFamilyOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3793E1162D6AFE1000113EF5 /* AosFamilyOrder.swift */; };
+		37A0EA182DE6DDD800E052A0 /* SavedSpecies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A0EA172DE6DDD800E052A0 /* SavedSpecies.swift */; };
 		37BCA9262D3B089800AA10CA /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BCA9252D3B089800AA10CA /* Filter.swift */; };
 		37BCA9342D4CA5DC00AA10CA /* ReportHistogram.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BCA9332D4CA5DC00AA10CA /* ReportHistogram.swift */; };
 		37BCA9372D506DB700AA10CA /* DateUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37BCA9362D506DB700AA10CA /* DateUtil.swift */; };
@@ -64,6 +65,7 @@
 		378AF5C52D16104D00AC77A8 /* SpeciesDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeciesDetailView.swift; sourceTree = "<group>"; };
 		3793E1142D6AFDE000113EF5 /* aos_family_order.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = aos_family_order.txt; sourceTree = "<group>"; };
 		3793E1162D6AFE1000113EF5 /* AosFamilyOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AosFamilyOrder.swift; sourceTree = "<group>"; };
+		37A0EA172DE6DDD800E052A0 /* SavedSpecies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedSpecies.swift; sourceTree = "<group>"; };
 		37BCA9252D3B089800AA10CA /* Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
 		37BCA9332D4CA5DC00AA10CA /* ReportHistogram.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportHistogram.swift; sourceTree = "<group>"; };
 		37BCA9362D506DB700AA10CA /* DateUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateUtil.swift; sourceTree = "<group>"; };
@@ -252,6 +254,7 @@
 				37F8889A2D0B643400258BDC /* Taxon.swift */,
 				37F8887B2D041BE400258BDC /* RespnoseModels.swift */,
 				37BCA9252D3B089800AA10CA /* Filter.swift */,
+				37A0EA172DE6DDD800E052A0 /* SavedSpecies.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -413,6 +416,7 @@
 				378AF5C22D1557FC00AC77A8 /* SpeciesItemView.swift in Sources */,
 				37F888922D0A1E1C00258BDC /* Location.swift in Sources */,
 				37F888672D0128BA00258BDC /* INatExplorerApp.swift in Sources */,
+				37A0EA182DE6DDD800E052A0 /* SavedSpecies.swift in Sources */,
 				37F8886A2D01297D00258BDC /* ReportListView.swift in Sources */,
 				37F8886C2D0190EB00258BDC /* ReportItemView.swift in Sources */,
 				37F62C942D1F568600FECE1A /* CategorySelectionView.swift in Sources */,


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/1edb5592-5275-484e-9a75-c3f856589ea3" width=50% height=50%>
<img src="https://github.com/user-attachments/assets/6a6be85b-5334-494d-ab35-06259f29d3ca" width=50% height=50%>
<img src="https://github.com/user-attachments/assets/1a50c9af-d06b-4e12-bc5e-5f2f62e29bce" width=50% height=50%>

- Add observed button on species list item.
- Add observed button on species detail screen.
- Save observed species IDs.
- Add toggle to only show unobserved species.
- Save toggle status.
