### PR TITLE
Use SpeciesItemViewModel to update label in species detail screen

### DIFF
--- a/INatExplorer/ViewModels/SpeciesItem.swift
+++ b/INatExplorer/ViewModels/SpeciesItem.swift
@@ -173,31 +173,45 @@ struct SpeciesSection: Identifiable {
         }
     }
     
-    func addLabel(speciesItem: SpeciesItem, label: SavedSpecies.Label) {
-        var labels = speciesItem.labels
-        guard !labels.contains(label) else { return }
+    func hasLabel(species: Species, label: SavedSpecies.Label) -> Bool {
+        guard let savedSpecies = savedSpeciesDict[species.taxon.id] else {
+            print("Species missing from saved species dictionary!")
+            return false
+        }
         
-        labels.append(label)
-        updateSpeciesLabels(speciesItem: speciesItem, labels: labels)
+        return savedSpecies.hasLabel(label)
     }
     
-    func removeLabel(speciesItem: SpeciesItem, label: SavedSpecies.Label) {
-        var labels = speciesItem.labels
-        guard labels.contains(label) else { return }
-        
-        labels.removeAll(where: { $0 == label })
-        updateSpeciesLabels(speciesItem: speciesItem, labels: labels)
-    }
-    
-    private func updateSpeciesLabels(speciesItem: SpeciesItem, labels: [SavedSpecies.Label]) {
-        guard let oldSavedSpecies = savedSpeciesDict[speciesItem.species.taxon.id] else {
+    func addLabel(species: Species, label: SavedSpecies.Label) {
+        guard let savedSpecies = savedSpeciesDict[species.taxon.id] else {
             print("Species missing from saved species dictionary!")
             return
         }
         
-        let newSavedSpecies: SavedSpecies = .init(species: speciesItem.species, labels: labels)
+        var labels = savedSpecies.labels
+        guard !labels.contains(label) else { return }
         
-        dataService.removeSavedSpecies([oldSavedSpecies])
+        labels.append(label)
+        updateSpeciesLabels(savedSpecies: savedSpecies, labels: labels)
+    }
+    
+    func removeLabel(species: Species, label: SavedSpecies.Label) {
+        guard let savedSpecies = savedSpeciesDict[species.taxon.id] else {
+            print("Species missing from saved species dictionary!")
+            return
+        }
+        
+        var labels = savedSpecies.labels
+        guard labels.contains(label) else { return }
+        
+        labels.removeAll(where: { $0 == label })
+        updateSpeciesLabels(savedSpecies: savedSpecies, labels: labels)
+    }
+    
+    private func updateSpeciesLabels(savedSpecies: SavedSpecies, labels: [SavedSpecies.Label]) {
+        let newSavedSpecies: SavedSpecies = .init(species: savedSpecies.species, labels: labels)
+        
+        dataService.removeSavedSpecies([savedSpecies])
         dataService.addSavedSpecies([newSavedSpecies])
         
         savedSpeciesDict[newSavedSpecies.species.taxon.id] = newSavedSpecies

--- a/INatExplorer/Views/Species/SpeciesDetailView.swift
+++ b/INatExplorer/Views/Species/SpeciesDetailView.swift
@@ -10,20 +10,20 @@ import SwiftUI
 
 struct SpeciesDetailView: View {
     
-    var speciesItem: SpeciesItem
+    var species: Species
+    @StateObject var speciesItemViewModel: SpeciesItemViewModel
+    
     @StateObject var taxonNamesViewModel = TaxonNamesViewModel()
     @StateObject var histogramViewModel = ReportHistogramViewModel()
     
-    @Binding var observed: Bool
-    
     var body: some View {
         ScrollView {
-            Text("\(speciesItem.species.name)\n\(taxonNamesViewModel.selectedTaxonName?.name ?? "-")")
+            Text("\(species.name)\n\(taxonNamesViewModel.selectedTaxonName?.name ?? "-")")
                 .multilineTextAlignment(.center)
                 .bold()
                 .padding(.horizontal)
             
-            AsyncImage(url: speciesItem.species.photo?.getUrl(.medium)) { image in
+            AsyncImage(url: species.photo?.getUrl(.medium)) { image in
                 image
                     .resizable()
                     .scaledToFit()
@@ -31,8 +31,14 @@ struct SpeciesDetailView: View {
                 Color.gray
             }
             .overlay(alignment: .topTrailing) {
+                let isObserved = speciesItemViewModel.hasLabel(species: species, label: .observed)
+                
                 Button {
-                    observed.toggle()
+                    if isObserved {
+                        speciesItemViewModel.removeLabel(species: species, label: .observed)
+                    } else {
+                        speciesItemViewModel.addLabel(species: species, label: .observed)
+                    }
                 } label: {
                     Image(systemName: SpeciesListView.Constants.observedIcon)
                         .resizable()
@@ -41,7 +47,7 @@ struct SpeciesDetailView: View {
                         .shadow(color: .gray, radius: 2)
                 }
                 .frame(width: 35, height: 35)
-                .tint(observed ? .orange : .gray)
+                .tint(isObserved ? .orange : .gray)
             }
             
             let lastYearHistogram = histogramViewModel.lastYearHistogram
@@ -94,7 +100,7 @@ struct SpeciesDetailView: View {
                 GridItem(.flexible(), alignment: .leading)
             ]
             
-            let taxons: [Taxon] = speciesItem.species.ancestors + [speciesItem.species.taxon]
+            let taxons: [Taxon] = species.ancestors + [species.taxon]
             
             LazyVGrid(columns: columns) {
                 ForEach(taxons) { taxon in
@@ -106,7 +112,7 @@ struct SpeciesDetailView: View {
         }
         .onAppear {
             Task {
-                let taxonId = speciesItem.species.taxon.id
+                let taxonId = species.taxon.id
                 
                 async let loadTaxonNames: () = taxonNamesViewModel.fetchData(taxonId: taxonId)
                 async let loadHistogram: () = histogramViewModel.fetchData(taxonId: taxonId)
@@ -118,7 +124,8 @@ struct SpeciesDetailView: View {
 }
 
 #Preview {
-    @Previewable @State var observed: Bool = false
-    
-    SpeciesDetailView(speciesItem: SpeciesItem.Constants.preview, observed: $observed)
+    SpeciesDetailView(
+        species: Species.Constants.preview,
+        speciesItemViewModel: SpeciesItemViewModel(dataService: .shared)
+    )
 }

--- a/INatExplorer/Views/Species/SpeciesListView.swift
+++ b/INatExplorer/Views/Species/SpeciesListView.swift
@@ -44,11 +44,11 @@ struct SpeciesListView: View {
                                     set: { newValue in
                                         if newValue {
                                             speciesItemViewModel.addLabel(
-                                                speciesItem: speciesItem, label: .observed
+                                                species: speciesItem.species, label: .observed
                                             )
                                         } else {
                                             speciesItemViewModel.removeLabel(
-                                                speciesItem: speciesItem, label: .observed
+                                                species: speciesItem.species, label: .observed
                                             )
                                         }
                                     }
@@ -56,7 +56,8 @@ struct SpeciesListView: View {
                                 
                                 NavigationLink {
                                     SpeciesDetailView(
-                                        speciesItem: speciesItem, observed: observedStatusBinding
+                                        species: speciesItem.species,
+                                        speciesItemViewModel: speciesItemViewModel
                                     )
                                 } label: {
                                     SpeciesItemView(


### PR DESCRIPTION
Fix the bug found in https://github.com/jqson/iNatExplorer/pull/6

- Pass `SpeciesItemViewModel` to `SpeciesDetailView` for label update.
- Use `Species` instead of `SpeciesItem` to identify species when handing labels.